### PR TITLE
FAD-4366 fixes issue with missing children for a and mx records

### DIFF
--- a/__tests__/helpers/tree.spec.js
+++ b/__tests__/helpers/tree.spec.js
@@ -1,0 +1,114 @@
+import { setupTree, flatten } from 'helpers/tree';
+import _ from 'lodash';
+
+describe('helpers: tree', () => {
+
+  let tree;
+
+  beforeEach(() => {
+    tree = {
+      record: 'root',
+      status: 'valid',
+      children: [
+        {
+          type: 'mx',
+          prefix: '+',
+          children: [
+            { value: 'some mx value 0' },
+            { value: 'some mx value 1' },
+            { value: 'some mx value 2' }
+          ]
+        },
+        {
+          type: 'a',
+          prefix: '+',
+          children: [
+            { value: 'some a value 0' },
+            { value: 'some a value 1' },
+            { value: 'some a value 2' }
+          ]
+        },
+        {
+          type: 'include',
+          prefix: '+',
+          value: 'somehost.com',
+          children: [
+            {
+              type: 'ip4',
+              prefix: '+',
+              value: '1.2.3.4'
+            }
+          ]
+        }
+      ]
+    };
+  });
+
+  describe('setupTree', () => {
+
+    it('should flatten MX and A children', () => {
+      const walked = setupTree(tree);
+      const mx = walked.children.slice(0, 3);
+      const a = walked.children.slice(3, 6);
+
+      expect(walked.children.length).toEqual(7);
+
+      // expect no children of type 'mx' or 'a'
+      expect(_.filter(walked.children, { type: 'mx' }).length).toEqual(0);
+      expect(_.filter(walked.children, { type: 'a' }).length).toEqual(0);
+
+      expect(mx).toEqual([
+        {
+          expanded: false,
+          displayType: 'mx',
+          value: 'some mx value 0'
+        },
+        {
+          expanded: false,
+          displayType: 'mx',
+          value: 'some mx value 1'
+        },
+        {
+          expanded: false,
+          displayType: 'mx',
+          value: 'some mx value 2'
+        },
+      ]);
+
+      expect(a).toEqual([
+        {
+          expanded: false,
+          displayType: 'a',
+          value: 'some a value 0'
+        },
+        {
+          expanded: false,
+          displayType: 'a',
+          value: 'some a value 1'
+        },
+        {
+          expanded: false,
+          displayType: 'a',
+          value: 'some a value 2'
+        },
+      ]);
+
+    });
+
+    it('should remove MX and A that have no children', () => {
+      delete tree.children[0].children;
+      delete tree.children[1].children;
+
+      const walked = setupTree(tree);
+
+      expect(walked.children.length).toEqual(1);
+
+      expect(_.filter(walked.children, { type: 'mx' }).length).toEqual(0);
+      expect(_.filter(walked.children, { type: 'a' }).length).toEqual(0);
+      expect(_.filter(walked.children, { displayType: 'mx' }).length).toEqual(0);
+      expect(_.filter(walked.children, { displayType: 'a' }).length).toEqual(0);
+    });
+
+  });
+
+});

--- a/src/helpers/tree.js
+++ b/src/helpers/tree.js
@@ -7,9 +7,10 @@ export function setupTree(node) {
   };
   const walked = Object.assign(defaults, node);
 
-  // mx and a records have child records, but no value of their own, flatten them to simplify the tree
+  // mx and a records may have child records, but no value of their own, flatten them to simplify the tree
   if (node.type === 'mx' || node.type === 'a') {
-    return node.children.map((child) => {
+    // node.children may be undefined, _.map will return an empty array, _.flatten will remove that empty array later
+    return _.map(node.children, (child) => {
       child.displayType = node.type;
       return setupTree(child);
     });

--- a/src/pages/spf/components/SPFNode.js
+++ b/src/pages/spf/components/SPFNode.js
@@ -17,7 +17,7 @@ function SPFNode({
   expand,
   collapse
 }) {
-  const label = domain ? domain : `${displayType}:${value}`;
+  const label = domain ? domain : [displayType, value].join(':'); // value may be undefined
   const hasChildren = children && children.length > 0;
 
   const onClick = () => {


### PR DESCRIPTION
in lodash we trust :latin_cross: 