### PR TITLE
FAD-4375 adds inline errors and warnings to spf tree

### DIFF
--- a/__tests__/helpers/tree.spec.js
+++ b/__tests__/helpers/tree.spec.js
@@ -1,0 +1,114 @@
+import { setupTree, flatten } from 'helpers/tree';
+import _ from 'lodash';
+
+describe('helpers: tree', () => {
+
+  let tree;
+
+  beforeEach(() => {
+    tree = {
+      record: 'root',
+      status: 'valid',
+      children: [
+        {
+          type: 'mx',
+          prefix: '+',
+          children: [
+            { value: 'some mx value 0' },
+            { value: 'some mx value 1' },
+            { value: 'some mx value 2' }
+          ]
+        },
+        {
+          type: 'a',
+          prefix: '+',
+          children: [
+            { value: 'some a value 0' },
+            { value: 'some a value 1' },
+            { value: 'some a value 2' }
+          ]
+        },
+        {
+          type: 'include',
+          prefix: '+',
+          value: 'somehost.com',
+          children: [
+            {
+              type: 'ip4',
+              prefix: '+',
+              value: '1.2.3.4'
+            }
+          ]
+        }
+      ]
+    };
+  });
+
+  describe('setupTree', () => {
+
+    it('should flatten MX and A children', () => {
+      const walked = setupTree(tree);
+      const mx = walked.children.slice(0, 3);
+      const a = walked.children.slice(3, 6);
+
+      expect(walked.children.length).toEqual(7);
+
+      // expect no children of type 'mx' or 'a'
+      expect(_.filter(walked.children, { type: 'mx' }).length).toEqual(0);
+      expect(_.filter(walked.children, { type: 'a' }).length).toEqual(0);
+
+      expect(mx).toEqual([
+        {
+          expanded: false,
+          displayType: 'mx',
+          value: 'some mx value 0'
+        },
+        {
+          expanded: false,
+          displayType: 'mx',
+          value: 'some mx value 1'
+        },
+        {
+          expanded: false,
+          displayType: 'mx',
+          value: 'some mx value 2'
+        },
+      ]);
+
+      expect(a).toEqual([
+        {
+          expanded: false,
+          displayType: 'a',
+          value: 'some a value 0'
+        },
+        {
+          expanded: false,
+          displayType: 'a',
+          value: 'some a value 1'
+        },
+        {
+          expanded: false,
+          displayType: 'a',
+          value: 'some a value 2'
+        },
+      ]);
+
+    });
+
+    it('should remove MX and A that have no children', () => {
+      delete tree.children[0].children;
+      delete tree.children[1].children;
+
+      const walked = setupTree(tree);
+
+      expect(walked.children.length).toEqual(1);
+
+      expect(_.filter(walked.children, { type: 'mx' }).length).toEqual(0);
+      expect(_.filter(walked.children, { type: 'a' }).length).toEqual(0);
+      expect(_.filter(walked.children, { displayType: 'mx' }).length).toEqual(0);
+      expect(_.filter(walked.children, { displayType: 'a' }).length).toEqual(0);
+    });
+
+  });
+
+});

--- a/__tests__/pages/spf/components/__snapshots__/SPFNode.spec.js.snap
+++ b/__tests__/pages/spf/components/__snapshots__/SPFNode.spec.js.snap
@@ -6,10 +6,13 @@ exports[`SPFNode Snapshots baseline snapshot 1`] = `
     onClick={[Function]}>
     <div
       className="panel__body">
-      <code
-        className="spf-tree__code spf-tree__code--mx spf-tree__code--label">
-        mx:_spf.erlock.homes
-      </code>
+      <span>
+        <code
+          className="spf-tree__code spf-tree__code--mx spf-tree__code--label">
+           
+          mx:_spf.erlock.homes
+        </code>
+      </span>
       <code
         className="spf-tree__code">
         sirMXaLot
@@ -29,10 +32,13 @@ exports[`SPFNode Snapshots should display domain if passed 1`] = `
     onClick={[Function]}>
     <div
       className="panel__body">
-      <code
-        className="spf-tree__code spf-tree__code--mx spf-tree__code--label">
-        domain.com
-      </code>
+      <span>
+        <code
+          className="spf-tree__code spf-tree__code--mx spf-tree__code--label">
+           
+          domain.com
+        </code>
+      </span>
       <code
         className="spf-tree__code">
         sirMXaLot
@@ -52,10 +58,13 @@ exports[`SPFNode Snapshots should not show record if missing 1`] = `
     onClick={[Function]}>
     <div
       className="panel__body">
-      <code
-        className="spf-tree__code spf-tree__code--mx">
-        mx:_spf.erlock.homes
-      </code>
+      <span>
+        <code
+          className="spf-tree__code spf-tree__code--mx">
+           
+          mx:_spf.erlock.homes
+        </code>
+      </span>
     </div>
     <div
       className="spf-tree__accent" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tools.sparkpost.com-ui",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": false,
   "devDependencies": {
     "@sparkpost/styles": "^1.5.8",

--- a/src/helpers/tree.js
+++ b/src/helpers/tree.js
@@ -7,9 +7,10 @@ export function setupTree(node) {
   };
   const walked = Object.assign(defaults, node);
 
-  // mx and a records have child records, but no value of their own, flatten them to simplify the tree
+  // mx and a records may have child records, but no value of their own, flatten them to simplify the tree
   if (node.type === 'mx' || node.type === 'a') {
-    return node.children.map((child) => {
+    // node.children may be undefined, _.map will return an empty array, _.flatten will remove that empty array later
+    return _.map(node.children, (child) => {
       child.displayType = node.type;
       return setupTree(child);
     });

--- a/src/helpers/tree.js
+++ b/src/helpers/tree.js
@@ -28,6 +28,15 @@ export function flatten({ top = {}, node, parent = null, id = 'root' }) {
   if (parent) {
     parent.children.push(id);
   }
+
+  node.status = 'valid';
+  if (node.warnings && node.warnings.length) {
+    node.status = 'warning';
+  }
+  if (node.errors && node.errors.length) {
+    node.status = 'error';
+  }
+
   if (node.children) {
     const children = [...node.children];
     node.children = [];

--- a/src/pages/spf/components/ResultsErrors.js
+++ b/src/pages/spf/components/ResultsErrors.js
@@ -17,8 +17,8 @@ export default (props) => {
 
     return (
       <h5>
-        {errors.length > 0 && <span className='spf-resultsErrors__summary has-error'><Icon name='exclamation-circle' /> {errorMessage}</span> }
-        {warnings.length > 0 && <span className='spf-resultsErrors__summary has-warning'><Icon name='exclamation-circle' /> {warningMessage}</span> }
+        {errors.length > 0 && <span className='spf-resultsErrors__summary has-error'><Icon name='exclamation-circle' extras='paddingRight--xs' />{errorMessage}</span> }
+        {warnings.length > 0 && <span className='spf-resultsErrors__summary has-warning'><Icon name='exclamation-triangle' extras='paddingRight--xs'/>{warningMessage}</span> }
       </h5>
     );
   };
@@ -28,7 +28,7 @@ export default (props) => {
   const renderRow = (error, idx, type) => (
     <div key={`e-${idx}`} className='panel__body'>
       <p>
-        <span className={`has-${type}`}><Icon name={type === 'error' ? 'exclamation-circle' : 'exlamcation-triangle'} /> </span>
+        <Icon name={type === 'error' ? 'exclamation-circle' : 'exclamation-triangle'} extras={`paddingRight--xs has-${type}`}/>
         {error.message}
       </p>
     </div>

--- a/src/pages/spf/components/SPFNode.js
+++ b/src/pages/spf/components/SPFNode.js
@@ -17,7 +17,7 @@ function SPFNode({
   expand,
   collapse
 }) {
-  const label = domain ? domain : `${displayType}:${value}`;
+  const label = domain ? domain : [displayType, value].join(':'); // value may be undefined
   const hasChildren = children && children.length > 0;
 
   const onClick = () => {

--- a/src/pages/spf/components/SPFNode.js
+++ b/src/pages/spf/components/SPFNode.js
@@ -14,11 +14,28 @@ function SPFNode({
   root = false,
   children = null,
   expanded = true,
+  status = 'valid',
+  warnings = [],
+  errors = [],
   expand,
   collapse
 }) {
   const label = domain ? domain : [displayType, value].join(':'); // value may be undefined
   const hasChildren = children && children.length > 0;
+  const isValid = status === 'valid';
+  const panelType = isValid ? displayType : status;
+  const iconMap = {
+    warning: 'exclamation-triangle',
+    error: 'exclamation-circle'
+  };
+
+  let errorMessage;
+  if (warnings.length) {
+    errorMessage = warnings[0].message;
+  }
+  if (errors.length) {
+    errorMessage = errors[0].message;
+  }
 
   const onClick = () => {
     if (!hasChildren) {
@@ -28,17 +45,17 @@ function SPFNode({
   };
 
   // TODO see if we can anchor link to panel with error
-  // TODO add child type 'error'
 
   const panelClasses = classNames('panel', {
     'spf-tree__child': !root,
     'spf-tree__root': root,
-    [`spf-tree__child--${displayType}`]: !root && displayType,
+    [`spf-tree__child--${panelType}`]: !root && panelType,
     'can-expand': hasChildren
   });
 
   const labelClasses = classNames('spf-tree__code', {
-    [`spf-tree__code--${displayType}`]: displayType,
+    [`spf-tree__code--${displayType}`]: isValid && displayType,
+    [`spf-tree__code--${status}`]: !isValid,
     'spf-tree__code--label': record
   });
 
@@ -51,7 +68,12 @@ function SPFNode({
       <div className={panelClasses} onClick={onClick}>
         <div className='panel__body'>
 
-          <code className={labelClasses}>{ label }</code>
+          <span>
+            {!isValid && <Icon name={ iconMap[status] } extras={ `has-${status}` } />}
+            <code className={labelClasses}> { label }</code>
+          </span>
+          {errorMessage && <div> { errorMessage }</div>}
+
           {record && <code className='spf-tree__code'>{ record }</code>}
           {hasChildren && <Icon name='chevron-up' extras={toggleClasses} />}
 

--- a/src/pages/spf/components/SPFNode.js
+++ b/src/pages/spf/components/SPFNode.js
@@ -1,3 +1,4 @@
+/* eslint complexity: ["error", 8] */
 import React from 'react';
 import classNames from 'classnames';
 import Icon from 'components/Icon';
@@ -56,7 +57,7 @@ function SPFNode({
   const labelClasses = classNames('spf-tree__code', {
     [`spf-tree__code--${displayType}`]: isValid && displayType,
     [`spf-tree__code--${status}`]: !isValid,
-    'spf-tree__code--label': record
+    'spf-tree__code--label': record || !isValid
   });
 
   const toggleClasses = classNames('spf-tree__chevron', {

--- a/src/pages/spf/components/SPFNode.scss
+++ b/src/pages/spf/components/SPFNode.scss
@@ -25,6 +25,14 @@
     // Color Coding
     &--redirect { color: color(teal);    }
     &--include  { color: color(magenta); }
+    &--warning  {
+      display: inline;
+      color: color(mustard);
+    }
+    &--error    {
+      display: inline;
+      color: color(alert);
+    }
   }
 
   &__children {
@@ -76,6 +84,8 @@
     // Color Coding
     &--redirect > .spf-tree__accent { background: color(teal);    }
     &--include  > .spf-tree__accent { background: color(magenta); }
+    &--warning  > .spf-tree__accent { background: color(mustard); }
+    &--error  > .spf-tree__accent { background: color(alert); }
   }
 
   // Can't have 3 pseudo elements, and border messes up margins so...

--- a/src/styles/_helpers.scss
+++ b/src/styles/_helpers.scss
@@ -1,0 +1,2 @@
+.has-error   { color: color(alert);   }
+.has-warning { color: color(mustard); }

--- a/src/styles/tools.scss
+++ b/src/styles/tools.scss
@@ -30,6 +30,7 @@ $fa-font-path: "~@sparkpost/styles/src/assets/fonts";
 @import "~@sparkpost/styles/src/assets/scss/components/popover";
 
 @import "./layout";
+@import "./_helpers";
 
 // This is a global override, we only use one input error
 // TODO change later


### PR DESCRIPTION
This PR focuses on the styling and displaying of errors and warnings in place. We still need to look at how we structure the data for cases like failed MX record lookups, but I think we need to tackle that holistically in another ticket.

I had to diverge from the mockup a little bit: we don't have context for the top level errors so we can't indicate at the top level of the page where the errors occur, so instead I'm showing the errors/warnings in place. The error/warning text could use a little styling too :)