### PR TITLE
ERRORS AF (FAD-4376)

### DIFF
--- a/__tests__/components/__snapshots__/Error.spec.js.snap
+++ b/__tests__/components/__snapshots__/Error.spec.js.snap
@@ -12,7 +12,7 @@ exports[`ErrorMessage component should render correctly with a supplied icon 1`]
       } />
     <p
       className="errorMessage__friendly">
-      Something happened!
+      An error occurred
     </p>
   </div>
 </div>
@@ -77,7 +77,7 @@ exports[`ErrorMessage component should render the default message with no props 
       } />
     <p
       className="errorMessage__friendly">
-      Something happened!
+      An error occurred
     </p>
   </div>
 </div>

--- a/__tests__/pages/spf/Query.spec.js
+++ b/__tests__/pages/spf/Query.spec.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
-import { Query } from 'pages/spf/Query';
-
-describe('Query Snapshots', () => {
-  test('baseline snapshot', () => {
-    expect(renderer.create(<Query loggedIn={false}></Query>)).toMatchSnapshot();
-  });
-});

--- a/__tests__/pages/spf/QueryPage.spec.js
+++ b/__tests__/pages/spf/QueryPage.spec.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { QueryPage } from 'pages/spf/QueryPage';
+
+describe('QueryPage Snapshots', () => {
+  test('baseline snapshot', () => {
+    expect(renderer.create(<QueryPage loggedIn={false}></QueryPage>)).toMatchSnapshot();
+  });
+});

--- a/__tests__/pages/spf/__snapshots__/QueryPage.spec.js.snap
+++ b/__tests__/pages/spf/__snapshots__/QueryPage.spec.js.snap
@@ -1,4 +1,4 @@
-exports[`Query Snapshots baseline snapshot 1`] = `
+exports[`QueryPage Snapshots baseline snapshot 1`] = `
 <div
   className="flex center-xs">
   <div

--- a/__tests__/pages/spf/components/__snapshots__/ResultsHeader.spec.js.snap
+++ b/__tests__/pages/spf/components/__snapshots__/ResultsHeader.spec.js.snap
@@ -56,22 +56,6 @@ exports[`ResultsHeader Snapshots baseline snapshot 1`] = `
         Tested on 
       </p>
     </div>
-    <div
-      className="panel__body">
-      <div
-        className="flex">
-        <div
-          className="col-xs-3">
-          <b />
-           Authorized Netblocks
-        </div>
-        <div
-          className="col-xs-3">
-          <b />
-           DNS Lookups
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;

--- a/src/actions/dkim.js
+++ b/src/actions/dkim.js
@@ -7,19 +7,10 @@ const COOKIE_NAME = '_dkimTestEmail';
  * for saved dkim addresses
  */
 
-function saveValidatorEmail() {
-  return (result) => {
-    const { email } = result;
-
-    const expires = new Date();
-    expires.setFullYear(expires.getFullYear() + 1);
-    cookie.set(COOKIE_NAME, email, { expires });
-
-    return {
-      type: 'DKIM_SAVED_EMAIL',
-      email: email
-    };
-  };
+function saveValidatorEmail({ results: { email } }) {
+  const expires = new Date();
+  expires.setFullYear(expires.getFullYear() + 1);
+  cookie.set(COOKIE_NAME, email, { expires });
 }
 
 export function deleteSavedValidatorEmail() {
@@ -48,7 +39,7 @@ export function getValidatorEmail() {
       url: '/messaging-tools/validator-emails',
       method: 'post',
       chain: {
-        success: saveValidatorEmail()
+        success: saveValidatorEmail
       }
     }
   };

--- a/src/actions/spf.js
+++ b/src/actions/spf.js
@@ -1,18 +1,3 @@
-
-function chainedSaveHistory(domain) {
-  return (result) => {
-    const { errors, warnings } = result;
-    const hasErrors = (errors && errors.length);
-    const hasWarnings = (warnings && warnings.length);
-    let status = 'valid';
-
-    if (hasWarnings) { status = 'warning'; }
-    if (hasErrors) { status = 'error'; }
-
-    return saveHistory(domain, status);
-  };
-}
-
 export function saveHistory(domain, status) {
   return {
     type: 'SPARKPOST_API_REQUEST',
@@ -33,7 +18,12 @@ export function inspect(domain) {
       url: '/messaging-tools/spf/query',
       params: { domain },
       chain: {
-        success: chainedSaveHistory(domain)
+        success: ({ dispatch, getState, results: { status } }) => {
+          const { auth } = getState();
+          if (auth.loggedIn) {
+            dispatch(saveHistory(domain, status));
+          }
+        }
       }
     }
   };

--- a/src/components/errors/ApiErrorMessage.js
+++ b/src/components/errors/ApiErrorMessage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ErrorMessage from './ErrorMessage';
+
+export default ({ friendly, error }) => {
+  const { message: errMessage, response } = error;
+  const { message: apiMessage } = response.data.errors[0];
+  const details = `${errMessage} (${apiMessage})`;
+
+  return <ErrorMessage friendly={friendly} details={details} />;
+};

--- a/src/components/errors/ApiErrorMessage.js
+++ b/src/components/errors/ApiErrorMessage.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import ErrorMessage from './ErrorMessage';
+import _ from 'lodash';
 
 export default ({ friendly, error }) => {
-  const { message: errMessage, response } = error;
-  const { message: apiMessage } = response.data.errors[0];
-  const details = `${errMessage} (${apiMessage})`;
+  const { message, response = {} } = error;
+  const apiMessage = _.get(response, 'data.errors[0].message');
+
+  let details = message;
+
+  if (apiMessage) {
+    details += ` (${apiMessage})`;
+  }
 
   return <ErrorMessage friendly={friendly} details={details} />;
 };

--- a/src/components/errors/ErrorMessage.js
+++ b/src/components/errors/ErrorMessage.js
@@ -49,7 +49,7 @@ class ErrorMessage extends Component {
 }
 
 ErrorMessage.defaultProps = {
-  friendly: 'Something happened!',
+  friendly: 'An error occurred',
   details: null,
   icon: 'exclamation-circle'
 };

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,6 +1,7 @@
 export default {
   apiBase: 'no-default-set',
   appUrl: 'no-default-set',
+  apiRequestTimeout: 3000,
   authCookie: {
     name: 'website_auth',
     options: {

--- a/src/config/production.js
+++ b/src/config/production.js
@@ -1,4 +1,5 @@
 export default {
   apiBase: 'https://api.sparkpost.com/api/v1',
-  appUrl: 'https://app.sparkpost.com'
+  appUrl: 'https://app.sparkpost.com',
+  apiRequestTimeout: 10000
 };

--- a/src/helpers/http.js
+++ b/src/helpers/http.js
@@ -1,9 +1,12 @@
 import config from 'config/index';
 import axios from 'axios';
 
-const { authCookie, apiBase } = config;
+const { authCookie, apiBase, apiRequestTimeout } = config;
 
-const sparkpostRequest = axios.create({ baseURL: apiBase });
+const sparkpostRequest = axios.create({
+  baseURL: apiBase,
+  timeout: apiRequestTimeout
+});
 
 function useRefreshToken(refresh_token) {
   return sparkpostRequest({

--- a/src/middleware/sparkpostApiRequest.js
+++ b/src/middleware/sparkpostApiRequest.js
@@ -51,7 +51,7 @@ export default function sparkpostApiRequest({ dispatch, getState }) {
 
       // if we need to chain together another action, do it here
       if (typeof chain.success === 'function') {
-        dispatch(chain.success(results));
+        chain.success({ dispatch, getState, results });
       }
 
     }, ({ message, response = {} }) => {

--- a/src/middleware/sparkpostApiRequest.js
+++ b/src/middleware/sparkpostApiRequest.js
@@ -54,7 +54,7 @@ export default function sparkpostApiRequest({ dispatch, getState }) {
         dispatch(chain.success(results));
       }
 
-    }, ({ message, response }) => {
+    }, ({ message, response = {} }) => {
       // NOTE: if this is a 401, need to do a refresh to get
       // a new auth token and then re-dispatch this action
       if (response.status === 401 && auth.refreshToken && retries <= maxRefreshRetries) {

--- a/src/middleware/sparkpostApiRequest.js
+++ b/src/middleware/sparkpostApiRequest.js
@@ -5,7 +5,7 @@
  */
 
 import _ from 'lodash';
-import { refresh } from 'actions/auth';
+import { refresh, logout } from 'actions/auth';
 import { sparkpostRequest, useRefreshToken } from 'helpers/http';
 
 const maxRefreshRetries = 3;
@@ -75,8 +75,13 @@ export default function sparkpostApiRequest({ dispatch, getState }) {
             });
           });
       }
-      // any other API error should automatically fail
-      // TODO on 403 should we do an AUTH_LOG_OUT action?
+
+      // If we have a 401 and we're not refreshing, log the user out silently
+      if (response.status === 401) {
+        return dispatch(logout());
+      }
+
+      // any other API error should automatically fail, to be handled in the reducers/components
       dispatch({
         type: FAIL_TYPE,
         payload: { message, response }

--- a/src/pages/builder/containers/RecordContainer.js
+++ b/src/pages/builder/containers/RecordContainer.js
@@ -79,7 +79,7 @@ class RecordContainer extends Component {
               <CopyPopover stringToCopy={record}><ActionLink>Copy</ActionLink></CopyPopover>
             </div>
             <code className='marginBottom--sm'><strong>{record}</strong></code>
-            <p className='builder-record__instruction'>Add this TXT record to your DNS, then <Link to={`/spf/inspector/${form.values.domain}`}>check out the inspector</Link> to make sure you've set it up correctly.</p>
+            {(form.values.domain && !form.syncErrors.domain) && <p className='builder-record__instruction'>Add this TXT record to your DNS, then <Link to={`/spf/inspector/${form.values.domain}`}>check out the inspector</Link> to make sure you've set it up correctly.</p>}
           </div>
         </div>
         <div className='builder-record__ghost' ref={(ghost) => this.ghost = ghost} style={{ height: `${ghostHeight}px`}}/>

--- a/src/pages/builder/containers/RecordContainer.js
+++ b/src/pages/builder/containers/RecordContainer.js
@@ -79,7 +79,7 @@ class RecordContainer extends Component {
               <CopyPopover stringToCopy={record}><ActionLink>Copy</ActionLink></CopyPopover>
             </div>
             <code className='marginBottom--sm'><strong>{record}</strong></code>
-            <p className='builder-record__instruction'>Add this TXT record to your DNS, then <Link to='/spf/inspector/'>check out the inspector</Link> to make sure you've set it up correctly.</p>
+            <p className='builder-record__instruction'>Add this TXT record to your DNS, then <Link to={`/spf/inspector/${form.values.domain}`}>check out the inspector</Link> to make sure you've set it up correctly.</p>
           </div>
         </div>
         <div className='builder-record__ghost' ref={(ghost) => this.ghost = ghost} style={{ height: `${ghostHeight}px`}}/>

--- a/src/pages/dkim/HomePage.js
+++ b/src/pages/dkim/HomePage.js
@@ -4,6 +4,7 @@ import { ActionButton } from 'components/button/Button';
 import ShowEmail from './components/ShowEmail';
 import GenerateEmail from './components/GenerateEmail';
 import { getValidatorEmail, deleteSavedValidatorEmail, checkSavedValidatorEmail } from 'actions/dkim';
+import ApiErrorMessage from 'components/errors/ApiErrorMessage';
 import { connect } from 'react-redux';
 
 class HomePage extends Component {
@@ -31,20 +32,24 @@ class HomePage extends Component {
   }
 
   renderGenerateOrEmail() {
-    const { email, error } = this.props;
-
-    return email ? <ShowEmail email={email} /> : <GenerateEmail generate={() => this.props.getValidatorEmail()} error={error} />;
+    const { email, error, getValidatorEmail } = this.props;
+    return (
+      <div>
+        {error && <ApiErrorMessage friendly='Unable to generate email address, please try again.' error={error} />}
+        {email ? <ShowEmail email={email} /> : <GenerateEmail generate={() => getValidatorEmail()} />}
+      </div>
+    );
   }
 
   render() {
-    const { loading } = this.props;
+    const { loading, email } = this.props;
     return (
       <div className='flex center-xs'>
         <div className='col-xs-12 col-md-10 col-lg-8'>
           <h1>DKIM Validator</h1>
           <p className='marginBottom--lg'>{INTRO_TEXT}</p>
           {loading ? this.renderLoading() : this.renderGenerateOrEmail()}
-          {process.env.NODE_ENV === 'development' && this.renderDeleteCookie()}
+          {(email && process.env.NODE_ENV === 'development') && this.renderDeleteCookie()}
         </div>
       </div>
     );
@@ -58,4 +63,3 @@ export default connect(mapStateToProps, {
   deleteSavedValidatorEmail,
   checkSavedValidatorEmail
 })(HomePage);
-

--- a/src/pages/dkim/ResultDetailPage.js
+++ b/src/pages/dkim/ResultDetailPage.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import Table from 'components/table/Table';
 import ResultDetailHeader from './components/ResultDetailHeader';
 import { BackLink } from 'components/button/Button';
-import ErrorMessage from 'components/errors/ErrorMessage';
+import ApiErrorMessage from 'components/errors/ApiErrorMessage';
 import { DETAIL_ERROR_MESSAGE } from './constants';
 
 import { getValidatorDetailedResult } from 'actions/dkim';
@@ -45,7 +45,7 @@ class ResultDetailPage extends Component {
       <div className='flex center-xs'>
         <div className='col-xs-12 col-md-10'>
           <div className='text--left'><BackLink to={back} title='DKIM Results' /></div>
-          {error && <ErrorMessage friendly={DETAIL_ERROR_MESSAGE} details={error.message} />}
+          {error && <ApiErrorMessage friendly={DETAIL_ERROR_MESSAGE} error={error} />}
           {loading ? this.renderLoading() : this.renderDetails()}
         </div>
       </div>

--- a/src/pages/dkim/ResultListPage.js
+++ b/src/pages/dkim/ResultListPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import ResultListRow from './components/ResultListRow';
 import ResultListHeader from './components/ResultListHeader';
-import ErrorMessage from 'components/errors/ErrorMessage';
+import ApiErrorMessage from 'components/errors/ApiErrorMessage';
 import { LIST_ERROR_MESSAGE } from './constants';
 
 import { getValidatorResults } from 'actions/dkim';
@@ -39,7 +39,11 @@ class ResultListPage extends Component {
   }
 
   renderResults() {
-    const { tableRows } = this.props;
+    const { tableRows, error } = this.props;
+
+    if (error) {
+      return <ApiErrorMessage friendly={LIST_ERROR_MESSAGE} error={error} />;
+    }
 
     if (tableRows.length === 0) {
       return this.renderEmpty();
@@ -49,13 +53,11 @@ class ResultListPage extends Component {
   }
 
   render() {
-    const { error, loading } = this.props;
-    const { email } = this.props.params;
+    const { loading, params: { email } } = this.props;
 
     return (
       <div className='flex center-xs'>
         <div className='col-xs-12 col-md-10 col-lg-8'>
-          {(error && !loading) && <ErrorMessage friendly={LIST_ERROR_MESSAGE} details={error.message} />}
           <ResultListHeader email={email} getResults={() => this.props.getValidatorResults(email)}/>
           {loading ? this.renderLoading() : this.renderResults()}
         </div>
@@ -69,4 +71,3 @@ const mapStateToProps = ({ dkim }) => ({ ...dkim.resultsList });
 export default connect(mapStateToProps, {
   getValidatorResults
 })(ResultListPage);
-

--- a/src/pages/dkim/components/GenerateEmail.js
+++ b/src/pages/dkim/components/GenerateEmail.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import { ActionButton } from 'components/button/Button';
-import ErrorMessage from 'components/errors/ErrorMessage';
-
-const errorText = 'Sorry, something happened and we couldn\'t generate an address.';
 
 export default (props) => (
   <span>
-    {props.error && <ErrorMessage friendly={errorText} />}
     <div className='panel panel--accent'>
       <div className='panel__body paddingTop--xl paddingBottom--xl text--center'>
         <h4>To get started, click on the button below to generate an email address.</h4>

--- a/src/pages/spf/QueryPage.js
+++ b/src/pages/spf/QueryPage.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { INTRO_TEXT } from './constants';
 import HistoryList from './components/HistoryList';
 
-export class Query extends Component {
+export class QueryPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -78,9 +78,5 @@ export class Query extends Component {
   }
 }
 
-Query.propTypes = {
-  loggedIn: React.PropTypes.bool.isRequired
-};
-
 const mapStateToProps = ({ auth }) => ({ loggedIn: auth.loggedIn });
-export default withRouter(connect(mapStateToProps)(Query));
+export default withRouter(connect(mapStateToProps)(QueryPage));

--- a/src/pages/spf/ResultsPage.js
+++ b/src/pages/spf/ResultsPage.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import ResultsHeader from './components/ResultsHeader';
 import ResultsErrors from './components/ResultsErrors';
 import { BackLink, ActionLink } from 'components/button/Button';
-import { ErrorMessage } from 'components/errors/ErrorMessage';
+import ApiErrorMessage from 'components/errors/ApiErrorMessage';
 import { inspect, expandAll, collapseAll, expand, collapse } from 'actions/spf';
 
 import SPFNode from './components/SPFNode';
@@ -16,26 +16,39 @@ class ResultsPage extends Component {
   }
 
   renderBody() {
-    const { tree, loading, error, params, results, collapseAll, expandAll } = this.props;
-    const { domain } = params;
-
-    if (loading) {
-      return (
-        <div className='panel panel--accent'>
-          <div className='panel__body text--center paddingTop--xxl paddingBottom--xxl'>
-            <h4 className='text--muted'>Inspecting {domain}...</h4>
-          </div>
-        </div>
-      );
-    }
+    const { loading, error } = this.props;
 
     if (error) {
-      return <ErrorMessage message={error.message || error}></ErrorMessage>;
+      return this.renderError();
     }
 
+    if (loading) {
+      return this.renderLoading();
+    }
+
+    return this.renderResults();
+  }
+
+  renderError() {
+    const { params: { domain }, error } = this.props;
+    return <ApiErrorMessage friendly={`Currently unable to get results for ${domain}, please try again.`} error={error} />;
+  }
+
+  renderLoading() {
+    const { params: { domain } } = this.props;
+    return (
+      <div className='panel panel--accent'>
+        <div className='panel__body text--center paddingTop--xxl paddingBottom--xxl'>
+          <h4 className='text--muted'>Inspecting {domain}...</h4>
+        </div>
+      </div>
+    );
+  }
+
+  renderResults() {
+    const { tree, params: { domain }, results, collapseAll, expandAll } = this.props;
     return (
       <div>
-        <ResultsHeader {...results} domain={domain} refresh={() => this.props.inspect(domain)} />
         <ResultsErrors errors={results.spfErrors} warnings={results.spfWarnings} />
         <div className="panel marginBottom--none">
           <div className='panel__heading'>
@@ -53,9 +66,11 @@ class ResultsPage extends Component {
   }
 
   render() {
+    const { loading, results, inspect, params: { domain } } = this.props;
     return (
       <div>
         <BackLink to='/spf/inspector' title='Back to SPF Inspector' />
+        {!loading && <ResultsHeader {...results} domain={domain} refresh={() => inspect(domain)} />}
         {this.renderBody()}
       </div>
     );

--- a/src/pages/spf/components/HistoryList.js
+++ b/src/pages/spf/components/HistoryList.js
@@ -2,11 +2,26 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { getHistory } from 'actions/spf';
 import HistoryRow from './HistoryRow';
+import ApiErrorMessage from 'components/errors/ApiErrorMessage';
 
 export class HistoryList extends Component {
 
   componentDidMount() {
     this.props.getHistory();
+  }
+
+  renderBody() {
+    const { loading, error } = this.props;
+
+    if (error) {
+      return this.renderError();
+    }
+
+    if (loading) {
+      return this.renderLoading();
+    }
+
+    return this.renderResults();
   }
 
   renderResults() {
@@ -31,13 +46,17 @@ export class HistoryList extends Component {
     );
   }
 
+  renderError() {
+    const { error } = this.props;
+    return <ApiErrorMessage friendly='Unable to load query history' error={error} />;
+  }
+
   render() {
-    const { loading } = this.props;
     return (
-        <div className='text--left'>
-          <h4 className='marginBottom--xs'>SPF History</h4>
-          {loading ? this.renderLoading() : this.renderResults()}
-        </div>
+      <div className='text--left'>
+        <h4 className='marginBottom--xs'>SPF History</h4>
+        {this.renderBody()}
+      </div>
     );
   }
 }

--- a/src/pages/spf/components/ResultsHeader.js
+++ b/src/pages/spf/components/ResultsHeader.js
@@ -6,6 +6,19 @@ import classNames from 'classnames';
 export default (props) => {
   const { domain, timestamp, authorized_netblocks, dns_lookups, refresh } = props;
   const timeClasses = classNames('text--muted', 'marginBottom--none', { 'h-hide': !timestamp });
+  const info = (typeof authorized_netblocks === 'number' && typeof dns_lookups === 'number') ? (
+    <div className='panel__body'>
+      <div className="flex">
+        <div className="col-xs-3">
+          <b>{authorized_netblocks}</b> Authorized Netblocks
+        </div>
+        <div className="col-xs-3">
+          <b>{dns_lookups}</b> DNS Lookups
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div>
       <div className='panel panel--accent'>
@@ -20,18 +33,8 @@ export default (props) => {
           <p className={timeClasses}>Tested on {timestamp}</p>
         </div>
 
-
         {/*  Info section */}
-        <div className='panel__body'>
-          <div className="flex">
-            <div className="col-xs-3">
-              <b>{authorized_netblocks}</b> Authorized Netblocks
-            </div>
-            <div className="col-xs-3">
-              <b>{dns_lookups}</b> DNS Lookups
-            </div>
-          </div>
-        </div>
+        {info}
 
       </div>
     </div>

--- a/src/reducers/dkim/generateEmail.js
+++ b/src/reducers/dkim/generateEmail.js
@@ -1,11 +1,13 @@
 import makeReducer from 'reducers/makeReducer';
 
+const initialState = {
+  error: null,
+  email: null,
+  loading: false
+};
+
 export default makeReducer({
-  initialState: {
-    error: null,
-    email: null,
-    loading: false
-  },
+  initialState,
   types: {
     'DKIM_REMOVE_EMAIL': (state) => ({
       ...state,
@@ -16,17 +18,16 @@ export default makeReducer({
       email: action.email
     }),
     'DKIM_GENERATE_EMAIL_PENDING': (state) => ({
-      ...state,
+      ...initialState,
       loading: true
     }),
     'DKIM_GENERATE_EMAIL_SUCCESS': (state, action) => ({
-      ...state,
-      loading: false,
+      ...initialState,
       email: action.payload.email
     }),
     'DKIM_GENERATE_EMAIL_FAIL': (state, action) => ({
-      ...state,
-      error: action.payload.message
+      ...initialState,
+      error: action.payload
     })
   }
 });

--- a/src/reducers/dkim/generateEmail.js
+++ b/src/reducers/dkim/generateEmail.js
@@ -18,15 +18,21 @@ export default makeReducer({
       email: action.email
     }),
     'DKIM_GENERATE_EMAIL_PENDING': (state) => ({
-      ...initialState,
+      ...state,
+      email: null,
+      error: null,
       loading: true
     }),
     'DKIM_GENERATE_EMAIL_SUCCESS': (state, action) => ({
-      ...initialState,
+      ...state,
+      error: null,
+      loading: false,
       email: action.payload.email
     }),
     'DKIM_GENERATE_EMAIL_FAIL': (state, action) => ({
-      ...initialState,
+      ...state,
+      email: null,
+      loading: false,
       error: action.payload
     })
   }

--- a/src/reducers/dkim/resultsDetail.js
+++ b/src/reducers/dkim/resultsDetail.js
@@ -1,29 +1,31 @@
 import makeReducer from 'reducers/makeReducer';
 import { formatDate } from 'helpers/date';
 
+const initialState = {
+  error: null,
+  detailTableRows: [],
+  sigTableHeaders: ['Status', 'DKIM Selector (s=)', 'Signing Domain (d=)', 'Timestamp (t=)'],
+  sigTableRows: [],
+  loading: false
+};
+
 export default makeReducer({
-  initialState: {
-    error: null,
-    detailTableRows: [],
-    sigTableHeaders: ['Status', 'DKIM Selector (s=)', 'Signing Domain (d=)', 'Timestamp (t=)'],
-    sigTableRows: [],
-    loading: true
-  },
+  initialState,
   types: {
+    'DKIM_GET_DETAILED_RESULT_PENDING': (state) => ({ ...state, loading: true }),
     'DKIM_GET_DETAILED_RESULT_SUCCESS': (state, action) => ({
-      ...state,
+      ...initialState,
       detailTableRows: [
         ['Subject', action.payload.subject],
         ['From', action.payload.header_from],
         ['On', formatDate(action.payload.received)],
         ['Status', action.payload.result ? 'Passed' : 'Failed']
       ],
-      sigTableRows: action.payload.sigs.map(({ s, d, t, result }) => ([result ? 'Passed' : 'Failed', s, d, t || 'N/A'])),
-      loading: false
+      sigTableRows: action.payload.sigs.map(({ s, d, t, result }) => ([result ? 'Passed' : 'Failed', s, d, t || 'N/A']))
     }),
     'DKIM_GET_DETAILED_RESULT_FAIL': (state, action) => ({
-      ...state,
-      error: action.payload.message
+      ...initialState,
+      error: action.payload
     })
   }
 });

--- a/src/reducers/dkim/resultsDetail.js
+++ b/src/reducers/dkim/resultsDetail.js
@@ -14,7 +14,9 @@ export default makeReducer({
   types: {
     'DKIM_GET_DETAILED_RESULT_PENDING': (state) => ({ ...state, loading: true }),
     'DKIM_GET_DETAILED_RESULT_SUCCESS': (state, action) => ({
-      ...initialState,
+      ...state,
+      loading: false,
+      error: null,
       detailTableRows: [
         ['Subject', action.payload.subject],
         ['From', action.payload.header_from],
@@ -24,7 +26,10 @@ export default makeReducer({
       sigTableRows: action.payload.sigs.map(({ s, d, t, result }) => ([result ? 'Passed' : 'Failed', s, d, t || 'N/A']))
     }),
     'DKIM_GET_DETAILED_RESULT_FAIL': (state, action) => ({
-      ...initialState,
+      ...state,
+      detailTableRows: [],
+      sigTableRows: [],
+      loading: false,
       error: action.payload
     })
   }

--- a/src/reducers/dkim/resultsList.js
+++ b/src/reducers/dkim/resultsList.js
@@ -20,12 +20,16 @@ export default makeReducer({
       ));
 
       return {
-        ...initialState,
+        ...state,
+        loading: false,
+        error: null,
         tableRows: tableRows
       };
     },
     'DKIM_GET_RESULTS_FAIL': (state, action) => ({
-      ...initialState,
+      ...state,
+      loading: false,
+      tableRows: [],
       error: action.payload
     })
   }

--- a/src/reducers/dkim/resultsList.js
+++ b/src/reducers/dkim/resultsList.js
@@ -1,13 +1,16 @@
 import moment from 'moment';
 import makeReducer from 'reducers/makeReducer';
 
+const initialState = {
+  error: null,
+  tableRows: [],
+  loading: false
+};
+
 export default makeReducer({
-  initialState: {
-    error: null,
-    tableRows: [],
-    loading: false
-  },
+  initialState,
   types: {
+    'DKIM_GET_RESULTS_PENDING': (state) => ({ ...state, loading: true }),
     'DKIM_GET_RESULTS_SUCCESS': (state, action) => {
       const tableRows = action.payload.map(({ id, subject, result, header_from, received }) => (
         {
@@ -17,14 +20,13 @@ export default makeReducer({
       ));
 
       return {
-        ...state,
-        loading: false,
+        ...initialState,
         tableRows: tableRows
       };
     },
     'DKIM_GET_RESULTS_FAIL': (state, action) => ({
-      ...state,
-      error: action.payload.message
+      ...initialState,
+      error: action.payload
     })
   }
 });

--- a/src/reducers/spfHistory.js
+++ b/src/reducers/spfHistory.js
@@ -22,6 +22,7 @@ export default makeReducer({
     }),
     'SPF_GET_HISTORY_FAIL': (state, action) => ({
       ...state,
+      loading: false,
       error: action.payload
     })
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,7 +5,7 @@ import DKIMHome from 'pages/dkim/HomePage';
 import DKIMResults from 'pages/dkim/ResultListPage';
 import DKIMDetail from 'pages/dkim/ResultDetailPage';
 import NotFound from 'pages/notFound/NotFound';
-import SPFQuery from 'pages/spf/Query';
+import SPFQuery from 'pages/spf/QueryPage';
 import SPFResults from 'pages/spf/ResultsPage';
 import SPFBuilder from 'pages/builder/Builder';
 


### PR DESCRIPTION
Changes:
* Adds an AUTH_LOG_OUT action for when a 401 is received and retries are exceeded or no refresh is in place (or if refresh fails), to prevent further 401s and encourage a new log in (this also somewhat fixes the issue of tokens being badly shared between different *.sparkpost.com envs)
* Adds/improves error handling for any non-401 (or 401 w/o refresh in place) API error for SPF and DKIM, will now see an "ApiErrorMessage" component with expandable details in all cases.
* Removes bad loading issues for error cases
* Adds a 3s request timeout (value in config if we want to adjust) so that all API requests that take longer than 3s will error and display like other errors (without this they would stay loading for what seemed like forever?)