### PR TITLE
FAD 4406 Add GTM to tools.sparkpost.com

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -179,7 +179,8 @@ module.exports = {
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     // In development, this will be an empty string.
     new InterpolateHtmlPlugin({
-      PUBLIC_URL: publicUrl
+      PUBLIC_URL: publicUrl,
+      GTM_ID: 'GTM-KW77RZ'
     }),
     // Generates an `index.html` file with the <script> injected.
     new HtmlWebpackPlugin({

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -44,6 +44,14 @@ if (env['process.env'].NODE_ENV !== '"production"') {
   throw new Error('Production builds must have NODE_ENV=production.');
 }
 
+// handle setting Google Tag Manager ID depending on environment
+var gtmId;
+if (env['process.env'].REACT_APP_ENV === '"staging"') {
+  gtmId = 'GTM-N6D3QT';
+} else {
+  gtmId = 'GTM-WN7C84';
+}
+
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
@@ -186,7 +194,8 @@ module.exports = {
     // In production, it will be an empty string unless you specify "homepage"
     // in `package.json`, in which case it will be the pathname of that URL.
     new InterpolateHtmlPlugin({
-      PUBLIC_URL: publicUrl
+      PUBLIC_URL: publicUrl,
+      GTM_ID: gtmId
     }),
     // Generates an `index.html` file with the <script> injected.
     new HtmlWebpackPlugin({

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,11 @@
     <link rel="manifest" href="https://www.sparkpost.com/wp-content/themes/jolteon/favicons/manifest.json">
     <link rel="mask-icon" href="https://www.sparkpost.com/wp-content/themes/jolteon/favicons/safari-pinned-tab.svg" color="#5bbad5">
     <link rel="shortcut icon" href="https://www.sparkpost.com/wp-content/themes/jolteon/favicons/favicon.ico">
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','%GTM_ID%');</script>
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -21,6 +26,8 @@
     <title>SparkPost Messaging Tools</title>
   </head>
   <body>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=%GTM_ID%"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/config/development.js
+++ b/src/config/development.js
@@ -6,5 +6,6 @@ export default {
     options: {
       domain: '.sparkpost.dev'
     }
-  }
+  },
+  gtmId: 'GTM-KW77RZ'
 };

--- a/src/config/development.js
+++ b/src/config/development.js
@@ -6,6 +6,5 @@ export default {
     options: {
       domain: '.sparkpost.dev'
     }
-  },
-  gtmId: 'GTM-KW77RZ'
+  }
 };


### PR DESCRIPTION
This updates the webpack configs and index as follows:

* Adds GTM code to head and body of index.html
* Adds the variable `GTM_ID`, which gets parsed on builds by checking for `%GTM_ID%` in index.html