### PR TITLE
adds src param to all links to sparkpost app

### DIFF
--- a/__tests__/components/__snapshots__/Button.spec.js.snap
+++ b/__tests__/components/__snapshots__/Button.spec.js.snap
@@ -87,7 +87,7 @@ exports[`snapshot tests LinkButton will render correctly with no options 1`] = `
 exports[`snapshot tests SpLoginLink will render correctly with all options 1`] = `
 <a
   className="sp-sign-in a-list of-classes"
-  href="https://TEST.sparkpost.com/auth?return=http://localhost/some/path?some=search"
+  href="https://TEST.sparkpost.com/auth?return=http://localhost/some/path?some=search&src=SP-Tools"
   title="Login">
   Log In
 </a>
@@ -96,7 +96,7 @@ exports[`snapshot tests SpLoginLink will render correctly with all options 1`] =
 exports[`snapshot tests SpLoginLink will render correctly with no options 1`] = `
 <a
   className="sp-sign-in"
-  href="https://TEST.sparkpost.com/auth?return=http://localhost"
+  href="https://TEST.sparkpost.com/auth?return=http://localhost&src=SP-Tools"
   title="Login" />
 `;
 

--- a/__tests__/components/__snapshots__/Nav.spec.js.snap
+++ b/__tests__/components/__snapshots__/Nav.spec.js.snap
@@ -7,7 +7,7 @@ exports[`Nav component should render correctly by default 1`] = `
       className="nav__right">
       <a
         className="sp-sign-in nav__link"
-        href="https://TEST.sparkpost.com/auth?return=http://localhost/some/path?maybe=something"
+        href="https://TEST.sparkpost.com/auth?return=http://localhost/some/path?maybe=something&src=SP-Tools"
         title="Login">
         Login
       </a>
@@ -180,7 +180,7 @@ exports[`Nav component should render correctly when not logged in 1`] = `
       className="nav__right">
       <a
         className="sp-sign-in nav__link"
-        href="https://TEST.sparkpost.com/auth?return=http://localhost/some/path?maybe=something"
+        href="https://TEST.sparkpost.com/auth?return=http://localhost/some/path?maybe=something&src=SP-Tools"
         title="Login">
         Login
       </a>
@@ -267,7 +267,7 @@ exports[`Nav component should render correctly with a builder path 1`] = `
       className="nav__right">
       <a
         className="sp-sign-in nav__link"
-        href="https://TEST.sparkpost.com/auth?return=http://localhost/spf/builder?maybe=something"
+        href="https://TEST.sparkpost.com/auth?return=http://localhost/spf/builder?maybe=something&src=SP-Tools"
         title="Login">
         Login
       </a>
@@ -354,7 +354,7 @@ exports[`Nav component should render correctly with a dkim path 1`] = `
       className="nav__right">
       <a
         className="sp-sign-in nav__link"
-        href="https://TEST.sparkpost.com/auth?return=http://localhost/dkim/path?maybe=something"
+        href="https://TEST.sparkpost.com/auth?return=http://localhost/dkim/path?maybe=something&src=SP-Tools"
         title="Login">
         Login
       </a>
@@ -441,7 +441,7 @@ exports[`Nav component should render correctly with an inspector path 1`] = `
       className="nav__right">
       <a
         className="sp-sign-in nav__link"
-        href="https://TEST.sparkpost.com/auth?return=http://localhost/spf/inspector?maybe=something"
+        href="https://TEST.sparkpost.com/auth?return=http://localhost/spf/inspector?maybe=something&src=SP-Tools"
         title="Login">
         Login
       </a>

--- a/__tests__/components/dkim/__snapshots__/ResultDetailHeader.spec.js.snap
+++ b/__tests__/components/dkim/__snapshots__/ResultDetailHeader.spec.js.snap
@@ -101,7 +101,7 @@ exports[`ResultDetailHeader component should render when not logged in 1`] = `
         className="popover__group popover__hoverTrigger">
         <a
           className="actionLink"
-          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/"
+          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/&src=SP-Tools"
           title="Save Results">
           Save Results
         </a>
@@ -206,7 +206,7 @@ exports[`ResultDetailHeader component should render with rows 1`] = `
         className="popover__group popover__hoverTrigger">
         <a
           className="actionLink"
-          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/"
+          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/&src=SP-Tools"
           title="Save Results">
           Save Results
         </a>

--- a/__tests__/components/dkim/__snapshots__/ResultListHeader.spec.js.snap
+++ b/__tests__/components/dkim/__snapshots__/ResultListHeader.spec.js.snap
@@ -9,7 +9,7 @@ exports[`ResultListHeader component should render 1`] = `
         className="popover__group popover__hoverTrigger">
         <a
           className="actionLink"
-          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/"
+          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/&src=SP-Tools"
           title="Save Results">
           Save Results
         </a>
@@ -142,7 +142,7 @@ exports[`ResultListHeader component should render when not logged in 1`] = `
         className="popover__group popover__hoverTrigger">
         <a
           className="actionLink"
-          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/"
+          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/&src=SP-Tools"
           title="Save Results">
           Save Results
         </a>
@@ -215,7 +215,7 @@ exports[`ResultListHeader component should render with an error present 1`] = `
         className="popover__group popover__hoverTrigger">
         <a
           className="actionLink"
-          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/"
+          href="https://TEST.sparkpost.com/sign-up?return=http://localhost/&src=SP-Tools"
           title="Save Results">
           Save Results
         </a>

--- a/__tests__/pages/spf/components/__snapshots__/ResultsHeader.spec.js.snap
+++ b/__tests__/pages/spf/components/__snapshots__/ResultsHeader.spec.js.snap
@@ -10,7 +10,7 @@ exports[`ResultsHeader Snapshots baseline snapshot 1`] = `
           className="popover__group popover__hoverTrigger">
           <a
             className="actionLink"
-            href="https://TEST.sparkpost.com/sign-up?return=http://localhost/"
+            href="https://TEST.sparkpost.com/sign-up?return=http://localhost/&src=SP-Tools"
             title="Save Results">
             Save Results
           </a>

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -19,6 +19,8 @@ const mapPropsToClasses = ({ type, size, accent, fullWidth, icon, states, extraC
   }, states, extraClasses)
 );
 
+const getLoginSignUpQueryParams = (location) => `return=${getCurrentUrl(location)}&src=SP-Tools`;
+
 const ActionButton = (props) => {
   const { action = noop, children } = props;
   const classes = mapPropsToClasses(props);
@@ -63,28 +65,23 @@ const BackLink = ({ to = null, title = '' }) => <Link to={to} className='backLin
 /**
  * Produces a Save Results action link
  */
-const SaveResultsLink = () => {
-  const currentUrl = getCurrentUrl(location);
-  return (
-    <HoverPopover placement='top' size='m' text='Create a free SparkPost account or login into your account to save results'>
-      <ActionLink external={`${config.appUrl}/sign-up?return=${currentUrl}`} className='actionLink' title='Save Results'>Save Results</ActionLink>
-    </HoverPopover>
-  );
-};
+const SaveResultsLink = () => (
+  <HoverPopover placement='top' size='m' text='Create a free SparkPost account or login into your account to save results'>
+    <ActionLink external={`${config.appUrl}/sign-up?${getLoginSignUpQueryParams(location)}`} className='actionLink' title='Save Results'>Save Results</ActionLink>
+  </HoverPopover>
+);
 
 const SpLoginLink = ({ location = {}, classes, children }) => {
-  const currentUrl = getCurrentUrl(location);
   const linkClasses = classNames('sp-sign-in', classes);
   return (
-    <a href={`${config.appUrl}/auth?return=${currentUrl}`} title='Login' className={linkClasses}>{children}</a>
+    <a href={`${config.appUrl}/auth?${getLoginSignUpQueryParams(location)}`} title='Login' className={linkClasses}>{children}</a>
   );
 };
 
 const SpSignUpLink = ({ location = {}, classes, children }) => {
-  const currentUrl = getCurrentUrl(location);
   const linkClasses = classNames('sp-sign-up', classes);
   return (
-    <a href={`${config.appUrl}/sign-up?return=${currentUrl}&src=SP-Tools`} title='Sign Up' className={linkClasses}>{children}</a>
+    <a href={`${config.appUrl}/sign-up?${getLoginSignUpQueryParams(location)}`} title='Sign Up' className={linkClasses}>{children}</a>
   );
 };
 


### PR DESCRIPTION
The `src` param was missing from the`SaveResultsLink` component. I added it there and also to the `SpLoginLink` component, in case people go to login, but actually need to sign up.