### PR TITLE
FAD-4401 remove robots.txt file for production site (leave for staging)

### DIFF
--- a/public/robots-prod.txt
+++ b/public/robots-prod.txt
@@ -1,0 +1,1 @@
+# WELCOME ROBOTS

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -74,9 +74,15 @@ recursive(paths.appBuild, (err, fileNames) => {
   // Merge with the public folder
   copyPublicFolder();
 
-  // remove robots.txt for prod site
+  const robots = path.join(paths.appBuild, 'robots.txt');
+  const robotsProd = path.join(paths.appBuild, 'robots-prod.txt');
+
+  // set up robots.txt for the environment
   if (process.env.REACT_APP_ENV === 'production') {
-    fs.removeSync(path.join(paths.appBuild, 'robots.txt'));
+    fs.removeSync(robots);
+    fs.renameSync(robotsProd, robots);
+  } else {
+    fs.removeSync(robotsProd);
   }
 });
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -73,6 +73,11 @@ recursive(paths.appBuild, (err, fileNames) => {
 
   // Merge with the public folder
   copyPublicFolder();
+
+  // remove robots.txt for prod site
+  if (process.env.REACT_APP_ENV === 'production') {
+    fs.removeSync(path.join(paths.appBuild, 'robots.txt'));
+  }
 });
 
 // Print a detailed summary of build files.


### PR DESCRIPTION
What do you all think of this idea, keeping the robots.txt in place for staging and removing it in the build process for production?

```
$ npm run build

> tools.sparkpost.com-ui@1.10.2 build /Users/jrhodes/src/projects/tools-ui
> node scripts/build.js

Creating an optimized production build...
Compiled successfully.

$ ls -la build
total 24
drwxr-xr-x   7 jrhodes  staff   238 Feb 21 10:30 .
drwxr-xr-x  17 jrhodes  staff   578 Feb 21 09:57 ..
-rw-r--r--   1 jrhodes  staff   697 Feb 21 10:30 asset-manifest.json
drwxr-xr-x   8 jrhodes  staff   272 Feb 21 10:29 images
-rw-r--r--   1 jrhodes  staff  1592 Feb 21 10:30 index.html
-rw-r--r--   1 jrhodes  staff    26 Feb 21 10:29 robots.txt
drwxr-xr-x   5 jrhodes  staff   170 Feb 21 10:30 static
```

vs

```
$ REACT_APP_ENV=production npm run build

> tools.sparkpost.com-ui@1.10.2 build /Users/jrhodes/src/projects/tools-ui
> node scripts/build.js

Creating an optimized production build...
Compiled successfully.

$ ls -la build
total 16
drwxr-xr-x   6 jrhodes  staff   204 Feb 21 10:40 .
drwxr-xr-x  17 jrhodes  staff   578 Feb 21 09:57 ..
-rw-r--r--   1 jrhodes  staff   697 Feb 21 10:40 asset-manifest.json
drwxr-xr-x   8 jrhodes  staff   272 Feb 21 10:40 images
-rw-r--r--   1 jrhodes  staff  1592 Feb 21 10:40 index.html
drwxr-xr-x   5 jrhodes  staff   170 Feb 21 10:40 static
```