### PR TITLE
FAD-4519 redirects from / to www tools page

### DIFF
--- a/__tests__/components/__snapshots__/Nav.spec.js.snap
+++ b/__tests__/components/__snapshots__/Nav.spec.js.snap
@@ -39,8 +39,7 @@ exports[`Nav component should render correctly by default 1`] = `
       <div
         className="logo__divider marginLeft--xs marginRight--xs" />
       <a
-        onClick={[Function]}
-        style={Object {}}
+        href="https://www.sparkpost.com/email-tools"
         title="SparkPost Tools">
         <svg
           className="logo__property"
@@ -125,8 +124,7 @@ exports[`Nav component should render correctly when logged in 1`] = `
       <div
         className="logo__divider marginLeft--xs marginRight--xs" />
       <a
-        onClick={[Function]}
-        style={Object {}}
+        href="https://www.sparkpost.com/email-tools"
         title="SparkPost Tools">
         <svg
           className="logo__property"
@@ -212,8 +210,7 @@ exports[`Nav component should render correctly when not logged in 1`] = `
       <div
         className="logo__divider marginLeft--xs marginRight--xs" />
       <a
-        onClick={[Function]}
-        style={Object {}}
+        href="https://www.sparkpost.com/email-tools"
         title="SparkPost Tools">
         <svg
           className="logo__property"
@@ -299,8 +296,7 @@ exports[`Nav component should render correctly with a builder path 1`] = `
       <div
         className="logo__divider marginLeft--xs marginRight--xs" />
       <a
-        onClick={[Function]}
-        style={Object {}}
+        href="https://www.sparkpost.com/email-tools"
         title="SparkPost Tools">
         <svg
           className="logo__property"
@@ -386,8 +382,7 @@ exports[`Nav component should render correctly with a dkim path 1`] = `
       <div
         className="logo__divider marginLeft--xs marginRight--xs" />
       <a
-        onClick={[Function]}
-        style={Object {}}
+        href="https://www.sparkpost.com/email-tools"
         title="SparkPost Tools">
         <svg
           className="logo__property"
@@ -473,8 +468,7 @@ exports[`Nav component should render correctly with an inspector path 1`] = `
       <div
         className="logo__divider marginLeft--xs marginRight--xs" />
       <a
-        onClick={[Function]}
-        style={Object {}}
+        href="https://www.sparkpost.com/email-tools"
         title="SparkPost Tools">
         <svg
           className="logo__property"

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -83,7 +83,7 @@ export class Nav extends Component {
           <div className='logo__wrapper'>
             <a href='http://sparkpost.com' title='SparkPost'><Logo/></a>
             <div className='logo__divider marginLeft--xs marginRight--xs' />
-            <Link to='/' title='SparkPost Tools'><Property/></Link>
+            <a href='https://www.sparkpost.com/email-tools' title='SparkPost Tools'><Property/></a>
           </div>
 
           <a className='nav__hamburger' onClick={() => this.toggleMenu()}><span></span></a>

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IndexRoute, Route, Redirect } from 'react-router';
+import { IndexRoute, IndexRedirect, Route, Redirect } from 'react-router';
 import App from 'components/App';
 import DKIMHome from 'pages/dkim/HomePage';
 import DKIMResults from 'pages/dkim/ResultListPage';
@@ -22,13 +22,13 @@ export default (
     </Route>
 
     <Route path='/spf' component={App}>
-      <IndexRoute to='inspector' />
+      <IndexRedirect to='inspector' />
+
       <Route path='inspector' component={SPFQuery} />
       <Route path='inspector/:domain' component={SPFResults} />
       <Redirect from='inspector/results/:domain' to='/spf/inspector/:domain' />
 
       <Route path='builder' component={SPFBuilder} />
-
     </Route>
 
     <Route path='*' component={App} >

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Redirect } from 'react-router';
+import { IndexRoute, Route, Redirect } from 'react-router';
 import App from 'components/App';
 import DKIMHome from 'pages/dkim/HomePage';
 import DKIMResults from 'pages/dkim/ResultListPage';
@@ -11,22 +11,26 @@ import SPFBuilder from 'pages/builder/Builder';
 
 export default (
   <Route>
-    <Redirect from='/' to='/external-tools' />
-    <Route path='/' component={App}>
-      <Redirect from='/dkim/results' to='/dkim' />
-      <Route path='dkim' component={DKIMHome} />
-      <Route path='dkim/results/:email' component={DKIMResults} />
-      <Route path='dkim/results/:email/:detailId' component={DKIMDetail} />
+    <Route path='/' onEnter={() => window.location = 'https://www.sparkpost.com/email-tools'} />
 
-      <Route path='spf/builder' component={SPFBuilder} />
+    <Route path='/dkim' component={App}>
+      <Redirect from='results' to='/' />
 
-      <Route path='spf/inspector' component={SPFQuery} />
-      <Redirect from='/spf' to='/spf/inspector' />
-      <Route path='spf/inspector/:domain' component={SPFResults} />
-      <Redirect from='/spf/inspector/results/:domain' to='/spf/inspector/:domain' />
-
-      <Route path='external-tools' onEnter={() => window.location = 'https://www.sparkpost.com/email-tools'} />
-      <Route path='*' component={NotFound} />
+      <IndexRoute component={DKIMHome} />
+      <Route path='results/:email' component={DKIMResults} />
+      <Route path='results/:email/:detailId' component={DKIMDetail} />
     </Route>
+
+    <Route path='/spf' component={App}>
+      <Route path='builder' component={SPFBuilder} />
+
+      <Redirect from='/' to='/spf/inspector' />
+      <Route path='inspector' component={SPFQuery} />
+      <Route path='inspector/:domain' component={SPFResults} />
+
+      <Redirect from='inspector/results/:domain' to='/spf/inspector/:domain' />
+    </Route>
+
+    <Route path='*' component={NotFound} />
   </Route>
 );

--- a/src/routes.js
+++ b/src/routes.js
@@ -14,23 +14,25 @@ export default (
     <Route path='/' onEnter={() => window.location = 'https://www.sparkpost.com/email-tools'} />
 
     <Route path='/dkim' component={App}>
-      <Redirect from='results' to='/' />
-
       <IndexRoute component={DKIMHome} />
+
+      <Redirect from='results' to='/' />
       <Route path='results/:email' component={DKIMResults} />
       <Route path='results/:email/:detailId' component={DKIMDetail} />
     </Route>
 
     <Route path='/spf' component={App}>
-      <Route path='builder' component={SPFBuilder} />
-
-      <Redirect from='/' to='/spf/inspector' />
+      <IndexRoute to='inspector' />
       <Route path='inspector' component={SPFQuery} />
       <Route path='inspector/:domain' component={SPFResults} />
-
       <Redirect from='inspector/results/:domain' to='/spf/inspector/:domain' />
+
+      <Route path='builder' component={SPFBuilder} />
+
     </Route>
 
-    <Route path='*' component={NotFound} />
+    <Route path='*' component={App} >
+      <IndexRoute component={NotFound}/>
+    </Route>
   </Route>
 );

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,7 +16,7 @@ export default (
     <Route path='/dkim' component={App}>
       <IndexRoute component={DKIMHome} />
 
-      <Redirect from='results' to='/' />
+      <Redirect from='results' to='/dkim' />
       <Route path='results/:email' component={DKIMResults} />
       <Route path='results/:email/:detailId' component={DKIMDetail} />
     </Route>

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,7 +11,7 @@ import SPFBuilder from 'pages/builder/Builder';
 
 export default (
   <Route>
-    <Redirect from='/' to='/dkim' />
+    <Redirect from='/' to='/external-tools' />
     <Route path='/' component={App}>
       <Redirect from='/dkim/results' to='/dkim' />
       <Route path='dkim' component={DKIMHome} />
@@ -24,6 +24,8 @@ export default (
       <Redirect from='/spf' to='/spf/inspector' />
       <Route path='spf/inspector/:domain' component={SPFResults} />
       <Redirect from='/spf/inspector/results/:domain' to='/spf/inspector/:domain' />
+
+      <Route path='external-tools' onEnter={() => window.location = 'https://www.sparkpost.com/email-tools'} />
       <Route path='*' component={NotFound} />
     </Route>
   </Route>


### PR DESCRIPTION
React router won't redirect to an external page, so I used the `onEnter` lifecycle hook to intercept a route and do a redirect. Using `onEnter` keeps React Router from adding the route to the browser history, so the back button will still work.

You can test this by going to some page (like https://www.washingtonpost.com), then typing `http://tools.sparkpost.dev` into the address bar, which will ultimately take you to `https://www.sparkpost.com/email-tools`. Clicking back from there will take you to `https://www.washingtonpost.com`.

Also democracy dies in darkness.