### PR TITLE
FE-579 Messaging tools chokes on API calls when logged in

### DIFF
--- a/__tests__/reducers/auth.spec.js
+++ b/__tests__/reducers/auth.spec.js
@@ -14,7 +14,7 @@ describe('reducers: auth', () => {
     action = {
       type: 'AUTH_LOG_IN',
       payload: {
-        'access_token': 'my_token',
+        access_token: 'my_token',
         refreshToken: 'my_refresh_token'
       }
     };

--- a/__tests__/reducers/auth.spec.js
+++ b/__tests__/reducers/auth.spec.js
@@ -2,7 +2,7 @@ import authReducer from 'reducers/auth';
 
 describe('reducers: auth', () => {
 
-  let previousState;
+  let previousState, action;
 
   beforeEach(() => {
     previousState = {
@@ -10,43 +10,46 @@ describe('reducers: auth', () => {
       username: 'old_username',
       refreshToken: 'old_refresh'
     };
-  })
+
+    action = {
+      type: 'AUTH_LOG_IN',
+      payload: {
+        'access_token': 'my_token',
+        refreshToken: 'my_refresh_token'
+      }
+    };
+  });
 
   it('should return a default state', () => {
     expect(authReducer()).toBeDefined();
   });
 
   it('should return correct state for AUTH_LOG_IN action', () => {
-    const action = {
-      type: 'AUTH_LOG_IN',
-      payload: {
-        token: 'my_token',
-        username: 'cool_user',
-        refreshToken: 'my_refresh_token'
-      }
+    action.payload.username = 'cool_user';
+    const result = {
+      token: 'my_token',
+      username: 'cool_user',
+      refreshToken: 'my_refresh_token'
     };
     previousState.loggedIn = false;
     const state = authReducer(previousState, action);
     expect(state).not.toBe(previousState);
     expect(state).toEqual({
-      ...action.payload,
+      ...result,
       loggedIn: true
     });
   });
 
   it('should return correct state for AUTH_LOG_IN when no username is provided', () => {
-    const action = {
-      type: 'AUTH_LOG_IN',
-      payload: {
-        token: 'my_token',
-        refreshToken: 'my_refresh_token'
-      }
+    const result = {
+      token: 'my_token',
+      refreshToken: 'my_refresh_token'
     };
     previousState.loggedIn = false;
     const state = authReducer(previousState, action);
     expect(state).not.toBe(previousState);
     expect(state).toEqual({
-      ...action.payload,
+      ...result,
       username: 'old_username',
       loggedIn: true
     });

--- a/src/config/development.js
+++ b/src/config/development.js
@@ -1,12 +1,11 @@
 export default {
-  apiBase: 'http://api.sparkpost.dev/api/v1',
-  // appUrl: 'https://app-uat.tst.sparkpost.com'
-  appUrl: 'http://app.sparkpost.dev',
-  logInUrl: 'http://app.sparkpost.dev/auth',
-  signUpUrl: 'http://app.sparkpost.dev/join',
+  apiBase: 'http://api.sparkpost.test/api/v1',
+  appUrl: 'http://app.sparkpost.test',
+  logInUrl: 'http://app.sparkpost.test/auth',
+  signUpUrl: 'http://app.sparkpost.test/join',
   authCookie: {
     options: {
-      domain: '.sparkpost.dev'
+      domain: '.sparkpost.test'
     }
   }
 };

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -6,7 +6,7 @@ export default makeReducer({
   },
   types: {
     'AUTH_LOG_IN': (state, action) => {
-      const { 'access_token': token, username = state.username, refreshToken } = action.payload;
+      const { access_token: token, username = state.username, refreshToken } = action.payload;
       return {
         token,
         username,

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -6,7 +6,7 @@ export default makeReducer({
   },
   types: {
     'AUTH_LOG_IN': (state, action) => {
-      const { token, username = state.username, refreshToken } = action.payload;
+      const { 'access_token': token, username = state.username, refreshToken } = action.payload;
       return {
         token,
         username,


### PR DESCRIPTION
- Changed the destructured variable from 'token' to 'access_token' but then renaming to to 'token'
- Changed dev endpoints
- Updated tests

### Testing
- Verify that that the messaging tools-ui works
- Instead of localhost:3000, use  **app.sparkpost.test:3000**
