### PR TITLE
FE-1428 - change travis npm install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
     packages:
       # allows arch specific modules to be built
       - g++-4.8
-install: npm install
+install: npm ci
 script: npm test && npm run build
 deploy:
   - provider: s3


### PR DESCRIPTION
### What Changed
 - `npm install` -> `npm ci` for the travis.yml file
 
 
 https://docs.npmjs.com/cli/v7/commands/npm-ci