### PR TITLE
FE-1522 - Auth env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ This repo contains the [Messaging Tools UI](https://tools.sparkpost.com). API is
 
 ## Development
 
+### Environment Variables
+
+#### TOOLS_UI_AUTH: export TOOLS_UI_AUTH="{value from 1password here}"
+
 ### Installing Dependencies
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo contains the [Messaging Tools UI](https://tools.sparkpost.com). API is
 
 ### Environment Variables
 
-#### TOOLS_UI_AUTH: export TOOLS_UI_AUTH="{value from 1password here}"
+#### REACT_APP_TOOLS_UI_AUTH: export REACT_APP_TOOLS_UI_AUTH="{value from 1password here}"
 
 ### Installing Dependencies
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repo contains the [Messaging Tools UI](https://tools.sparkpost.com). API is
 
 #### REACT_APP_TOOLS_UI_AUTH: export REACT_APP_TOOLS_UI_AUTH="{value from 1password here}"
 
+Set this in your bash profile. 
+
 ### Installing Dependencies
 
 ```

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,4 +1,6 @@
-const AUTH = process.env.TOOLS_UI_AUTH;
+console.log('process.env: ', process.env);
+const AUTH = process.env.REACT_APP_TOOLS_UI_AUTH;
+console.log('AUTH: ', AUTH);
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,3 +1,5 @@
+const AUTH = process.env.TOOLS_UI_AUTH;
+
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
   apiBase: 'no-default-set',
@@ -12,7 +14,7 @@ export default {
       path: '/'
     },
     requestHeaders: {
-      Authorization: 'Basic bXN5c1VJTGltaXRlZDphZjE0OTdkYS02NjI5LTQ3NTEtODljZS01ZDBmODE4N2MyMDQ=',
+      Authorization: AUTH,
       'Content-Type': 'application/x-www-form-urlencoded'
     }
   },

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,6 +1,4 @@
-console.log('process.env: ', process.env);
 const AUTH = process.env.REACT_APP_TOOLS_UI_AUTH;
-console.log('AUTH: ', AUTH);
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {


### PR DESCRIPTION
 - Set auth based on env variable in default.js
 - Created a bash env variable for myself to test with. (called REACT_APP_TOOLS_UI_AUTH)
 - Added a note to the readme that this env is required for local dev.
 - Put the auth string in 1pass with a clear name for what it's for. 
 - Created a Travis CI env variable for all branches:
![image](https://user-images.githubusercontent.com/4204806/123993068-c0057300-d991-11eb-940a-449d00e0eb86.png)

